### PR TITLE
GetFileNamesAsync() pulling in the folders, not files

### DIFF
--- a/src/Cimbalino.Phone.Toolkit (WP8)/Services/AsyncStorageService.cs
+++ b/src/Cimbalino.Phone.Toolkit (WP8)/Services/AsyncStorageService.cs
@@ -183,7 +183,7 @@ namespace Cimbalino.Phone.Toolkit.Services
         /// <returns>The <see cref="Task"/> object representing the asynchronous operation.</returns>
         public async Task<string[]> GetFileNamesAsync()
         {
-            var files = await Storage.GetFoldersAsync();
+            var files = await Storage.GetFilesAsync();
 
             return files
                 .Select(x => x.Name)


### PR DESCRIPTION
GetFileNamesAsync() was pulling in the folders, not files and so
returning folder names, not file names.
