### PR TITLE
Removed unnecessary async/await keywords

### DIFF
--- a/src/Cimbalino.Phone.Toolkit.Background (WP8)/Services/AsyncStorageService.cs
+++ b/src/Cimbalino.Phone.Toolkit.Background (WP8)/Services/AsyncStorageService.cs
@@ -39,9 +39,9 @@ namespace Cimbalino.Phone.Toolkit.Services
         /// <param name="sourceFileName">The name of the file to copy.</param>
         /// <param name="destinationFileName">The name of the destination file. This cannot be a directory or an existing file.</param>
         /// <returns>The <see cref="Task"/> object representing the asynchronous operation.</returns>
-        public async Task CopyFileAsync(string sourceFileName, string destinationFileName)
+        public Task CopyFileAsync(string sourceFileName, string destinationFileName)
         {
-            await CopyFileAsync(sourceFileName, destinationFileName, false);
+            return CopyFileAsync(sourceFileName, destinationFileName, false);
         }
 
         /// <summary>
@@ -80,9 +80,9 @@ namespace Cimbalino.Phone.Toolkit.Services
         /// </summary>
         /// <param name="path">The relative path of the file to be created in the store.</param>
         /// <returns>The <see cref="Task"/> object representing the asynchronous operation.</returns>
-        public async Task<Stream> CreateFileAsync(string path)
+        public Task<Stream> CreateFileAsync(string path)
         {
-            return await Storage.OpenStreamForWriteAsync(path, CreationCollisionOption.ReplaceExisting);
+            return Storage.OpenStreamForWriteAsync(path, CreationCollisionOption.ReplaceExisting);
         }
 
         /// <summary>
@@ -237,9 +237,9 @@ namespace Cimbalino.Phone.Toolkit.Services
         /// </summary>
         /// <param name="path">The relative path of the file within the store.</param>
         /// <returns>The <see cref="Task"/> object representing the asynchronous operation.</returns>
-        public async Task<Stream> OpenFileForReadAsync(string path)
+        public Task<Stream> OpenFileForReadAsync(string path)
         {
-            return await Storage.OpenStreamForReadAsync(path);
+            return Storage.OpenStreamForReadAsync(path);
         }
 
         /// <summary>


### PR DESCRIPTION
I am Semih Okur, a PhD student in the CS department at the University of Illinois. I'm currently doing research on asynchronous programming in phone applications. I developed a tool that automatically improves async/await usages by doing transformations.

The tool found some opportunities in your application. There was no need to use async/await for 3 methods. It will decrease the overhead that is caused by async/await state machine and it will simplify the code. Removing async/await does not change the behavior at all. 

Are you interested in merging this pull request? If not, please let me know why.

Thanks for your time,
Semih Okur
