### PR TITLE
Allow a WriteableBitmap to be used multiple times and for multiple sizes.

### DIFF
--- a/src/Cimbalino.Phone.Toolkit.Background (WP71)/Extensions/WriteableBitmapExtensions.cs
+++ b/src/Cimbalino.Phone.Toolkit.Background (WP71)/Extensions/WriteableBitmapExtensions.cs
@@ -223,6 +223,18 @@ namespace Cimbalino.Phone.Toolkit.Extensions
             });
         }
 
+        /// <summary>
+        /// Will zero out all pixels of the WriteableBitmap. Use this method when you want to reuse the WriteableBitmap.
+        /// </summary>
+        /// <param name="writeableBitmap"></param>
+        public static void Clear(this WriteableBitmap writeableBitmap)
+        {
+            for (int i = 0; i < writeableBitmap.Pixels.Length; i++)
+            {
+                writeableBitmap.Pixels[i] = 0;
+            }
+        }
+
         private static void WriteHeader(Stream outputStream, Size desiredSize)
         {
             outputStream.Write(new byte[] { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A }, 0, 8);

--- a/src/Cimbalino.Phone.Toolkit.Background (WP71)/Extensions/WriteableBitmapExtensions.cs
+++ b/src/Cimbalino.Phone.Toolkit.Background (WP71)/Extensions/WriteableBitmapExtensions.cs
@@ -278,6 +278,12 @@ namespace Cimbalino.Phone.Toolkit.Extensions
                     var dataRowLength = width * 4;
                     var dataRow = new byte[dataRowLength];
 
+                    // only declare these once to save memory
+                    int dataRowOffset;
+                    int color;
+                    byte alpha;
+                    int alphaInt;
+
                     for (var y = 0; y < height; y++)
                     {
                         // shift pixels due to on requested size
@@ -285,10 +291,10 @@ namespace Cimbalino.Phone.Toolkit.Extensions
                         zlibStream.WriteByte(0);
                         for (var x = 0; x < width; x++)
                         {
-                            var color = pixels[index++];
-                            var alpha = (byte)(color >> 24);
+                            color = pixels[index++];
+                            alpha = (byte)(color >> 24);
 
-                            int alphaInt = alpha;
+                            alphaInt = alpha;
 
                             if (alphaInt == 0)
                             {
@@ -297,7 +303,7 @@ namespace Cimbalino.Phone.Toolkit.Extensions
 
                             alphaInt = (255 << 8) / alphaInt;
 
-                            var dataRowOffset = x * 4;
+                            dataRowOffset = x * 4;
 
                             dataRow[dataRowOffset] = (byte)((((color >> 16) & 0xFF) * alphaInt) >> 8);
                             dataRow[dataRowOffset + 1] = (byte)((((color >> 8) & 0xFF) * alphaInt) >> 8);


### PR DESCRIPTION
Also save on some managed memory by only declaring variables once.
